### PR TITLE
[Feature] Default page when there is no note open in the workspace

### DIFF
--- a/src/components/editor/EmptyWorkspace.vue
+++ b/src/components/editor/EmptyWorkspace.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup></script>
+
+<template>
+  <article class="empty-ws">
+    <h1 class="empty-ws__title">{{ $t("emptyWorkspace.title") }}</h1>
+    <p class="empty-ws__text">{{ $t("emptyWorkspace.subtitle") }}</p>
+  </article>
+</template>
+
+<style lang="scss" scoped>
+.empty-ws {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background-color: var(--color-base-90);
+  &__title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-base-20);
+  }
+  &__text {
+    font-size: 1rem;
+    font-weight: 400;
+    color: var(--color-base-30);
+  }
+}
+</style>

--- a/src/components/editor/NoteWorkspace.vue
+++ b/src/components/editor/NoteWorkspace.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import EmptyWorkspace from "./EmptyWorkspace.vue";
 import NoteEditor from "./NoteEditor.vue";
 import NoteWorkspaceHeader from "./NoteWorkspaceHeader.vue";
 import { useEditorStore } from "@/stores/editor";
@@ -32,6 +33,7 @@ function onToggleSidebar() {
     />
     <NoteEditor :note="note" id="ws__editor" />
   </div>
+  <EmptyWorkspace v-else />
 </template>
 
 <style scoped lang="scss">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -15,6 +15,10 @@
     "login": "Sign in",
     "logout": "Logout"
   },
+  "emptyWorkspace": {
+    "title": "No note selected",
+    "subtitle": "Create or select a note from the sidebar to start editing."
+  },
   "commandPalette": {
     "convertBlockType": {
       "plainText": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -15,6 +15,10 @@
     "login": "Iniciar sesión",
     "logout": "Salir de sesión"
   },
+  "emptyWorkspace": {
+    "title": "No hay ninguna nota seleccionada",
+    "subtitle": "Cree o seleccione una nota de la barra lateral para comenzar a escribir."
+  },
   "commandPalette": {
     "convertBlockType": {
       "plainText": {


### PR DESCRIPTION
Created a page with a default message that will appear whenever there is no selected note in the editor.